### PR TITLE
08: trpc setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,8 +38,13 @@
         "@radix-ui/react-toggle": "1.1.9",
         "@radix-ui/react-toggle-group": "1.1.10",
         "@radix-ui/react-tooltip": "1.2.7",
+        "@tanstack/react-query": "^5.76.1",
+        "@trpc/client": "^11.1.2",
+        "@trpc/server": "^11.1.2",
+        "@trpc/tanstack-react-query": "^11.1.2",
         "better-auth": "1.2.8",
         "class-variance-authority": "0.7.1",
+        "client-only": "^0.0.1",
         "clsx": "2.1.1",
         "cmdk": "1.1.1",
         "date-fns": "4.1.0",
@@ -56,10 +61,11 @@
         "react-hook-form": "7.60.0",
         "react-resizable-panels": "3.0.3",
         "recharts": "2.15.4",
+        "server-only": "^0.0.1",
         "sonner": "2.0.6",
         "tailwind-merge": "3.3.1",
         "vaul": "1.1.2",
-        "zod": "4.0.5"
+        "zod": "^3.25.7"
       },
       "devDependencies": {
         "@eslint/eslintrc": "3",
@@ -4338,6 +4344,74 @@
         "tailwindcss": "4.1.11"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.76.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.76.0.tgz",
+      "integrity": "sha512-FN375hb8ctzfNAlex5gHI6+WDXTNpe0nbxp/d2YJtnP+IBM6OUm7zcaoCW6T63BawGOYZBbKC0iPvr41TteNVg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.76.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.76.1.tgz",
+      "integrity": "sha512-YxdLZVGN4QkT5YT1HKZQWiIlcgauIXEIsMOTSjvyD5wLYK8YVvKZUPAysMqossFJJfDpJW3pFn7WNZuPOqq+fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.76.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@trpc/client": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@trpc/client/-/client-11.1.2.tgz",
+      "integrity": "sha512-RpifJOAv+ql9gF3oafa3dLCF01AzWu2DzejvehAPG2IlwHxopKoYXaImJ8zPwRkZokuWiKz5v65HjElmi8TlrQ==",
+      "funding": [
+        "https://trpc.io/sponsor"
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@trpc/server": "11.1.2",
+        "typescript": ">=5.7.2"
+      }
+    },
+    "node_modules/@trpc/server": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@trpc/server/-/server-11.1.2.tgz",
+      "integrity": "sha512-Oi9zWHG0ZDkbDo4sYkduoV7q4sIe6UwjrRLC91vNMYQK+PVgpbTCmK1laRwewAGu0zaayqcGDosANjceOIC3GA==",
+      "funding": [
+        "https://trpc.io/sponsor"
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5.7.2"
+      }
+    },
+    "node_modules/@trpc/tanstack-react-query": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@trpc/tanstack-react-query/-/tanstack-react-query-11.1.2.tgz",
+      "integrity": "sha512-c+NupnmIQmwgwYVTaHgDg59BZBtJ6KxqB0cxF9FBhKHPY6PlwGLdU8+mo25C5VIpofZYEII4H7NKE4yKGFSe3w==",
+      "funding": [
+        "https://trpc.io/sponsor"
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.67.1",
+        "@trpc/client": "11.1.2",
+        "@trpc/server": "11.1.2",
+        "react": ">=18.2.0",
+        "react-dom": ">=18.2.0",
+        "typescript": ">=5.7.2"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
@@ -5365,15 +5439,6 @@
         "kysely": "^0.28.1",
         "nanostores": "^0.11.3",
         "zod": "^3.24.1"
-      }
-    },
-    "node_modules/better-auth/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/better-call": {
@@ -9578,6 +9643,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
+    },
     "node_modules/set-cookie-parser": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
@@ -10679,9 +10750,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.5.tgz",
-      "integrity": "sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA==",
+      "version": "3.25.7",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.7.tgz",
+      "integrity": "sha512-YGdT1cVRmKkOg6Sq7vY7IkxdphySKnXhaUmFI4r4FcuFVNgpCb9tZfNwXbT6BPjD5oz0nubFsoo9pIqKrDcCvg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -45,8 +45,13 @@
     "@radix-ui/react-toggle": "1.1.9",
     "@radix-ui/react-toggle-group": "1.1.10",
     "@radix-ui/react-tooltip": "1.2.7",
+    "@tanstack/react-query": "5.76.1",
+    "@trpc/client": "11.1.2",
+    "@trpc/server": "11.1.2",
+    "@trpc/tanstack-react-query": "11.1.2",
     "better-auth": "1.2.8",
     "class-variance-authority": "0.7.1",
+    "client-only": "0.0.1",
     "clsx": "2.1.1",
     "cmdk": "1.1.1",
     "date-fns": "4.1.0",
@@ -63,10 +68,11 @@
     "react-hook-form": "7.60.0",
     "react-resizable-panels": "3.0.3",
     "recharts": "2.15.4",
+    "server-only": "0.0.1",
     "sonner": "2.0.6",
     "tailwind-merge": "3.3.1",
     "vaul": "1.1.2",
-    "zod": "4.0.5"
+    "zod": "3.25.7"
   },
   "devDependencies": {
     "@eslint/eslintrc": "3",

--- a/src/app/api/trpc/[trpc]/route.ts
+++ b/src/app/api/trpc/[trpc]/route.ts
@@ -1,0 +1,13 @@
+import { fetchRequestHandler } from '@trpc/server/adapters/fetch'
+
+import { createTRPCContext } from '@/trpc/init'
+import { appRouter } from '@/trpc/routers/_app'
+
+const handler = (req: Request) =>
+  fetchRequestHandler({
+    endpoint: '/api/trpc',
+    req,
+    router: appRouter,
+    createContext: createTRPCContext
+  })
+export { handler as GET, handler as POST }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next'
 import { Nunito } from 'next/font/google'
 
+import { TRPCReactProvider } from '@/trpc/client'
+
 import { Toaster } from '@/components/ui/sonner'
 
 import '@/styles/globals.css'
@@ -22,12 +24,14 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang='en'>
-      <body className={`${font.className} antialiased`}>
-        {children}
+    <TRPCReactProvider>
+      <html lang='en'>
+        <body className={`${font.className} antialiased`}>
+          {children}
 
-        <Toaster richColors theme='light' />
-      </body>
-    </html>
+          <Toaster richColors theme='light' />
+        </body>
+      </html>
+    </TRPCReactProvider>
   )
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,14 +24,14 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <TRPCReactProvider>
-      <html lang='en'>
-        <body className={`${font.className} antialiased`}>
+    <html lang='en'>
+      <body className={`${font.className} antialiased`}>
+        <TRPCReactProvider>
           {children}
 
           <Toaster richColors theme='light' />
-        </body>
-      </html>
-    </TRPCReactProvider>
+        </TRPCReactProvider>
+      </body>
+    </html>
   )
 }

--- a/src/modules/home/ui/views/home-view.tsx
+++ b/src/modules/home/ui/views/home-view.tsx
@@ -1,35 +1,15 @@
 'use client'
 
-import { useRouter } from 'next/navigation'
+import { useQuery } from '@tanstack/react-query'
 
-import { authClient } from '@/lib/auth-client'
-
-import { Button } from '@/components/ui/button'
+import { useTRPC } from '@/trpc/client'
 
 const HomeView = () => {
-  const router = useRouter()
+  const trpc = useTRPC()
 
-  const { data: session } = authClient.useSession()
+  const { data } = useQuery(trpc.hello.queryOptions({ text: 'jeancarlo' }))
 
-  return (
-    <div>
-      <div>Hello {session?.user?.name}</div>
-
-      <Button
-        onClick={() =>
-          authClient.signOut({
-            fetchOptions: {
-              onSuccess: () => {
-                router.push('/sign-in')
-              }
-            }
-          })
-        }
-      >
-        Sign out
-      </Button>
-    </div>
-  )
+  return <div className='flex flex-col gap-y-4 p-4'>{data?.greeting}</div>
 }
 
 export { HomeView }

--- a/src/trpc/client.tsx
+++ b/src/trpc/client.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+// ^-- to make sure we can mount the Provider from a server component
+import { useState } from 'react'
+
+import type { QueryClient } from '@tanstack/react-query'
+import { QueryClientProvider } from '@tanstack/react-query'
+import { createTRPCClient, httpBatchLink } from '@trpc/client'
+import { createTRPCContext } from '@trpc/tanstack-react-query'
+
+import { makeQueryClient } from './query-client'
+import type { AppRouter } from './routers/_app'
+
+export const { TRPCProvider, useTRPC } = createTRPCContext<AppRouter>()
+let browserQueryClient: QueryClient
+function getQueryClient() {
+  if (typeof window === 'undefined') {
+    // Server: always make a new query client
+    return makeQueryClient()
+  }
+  // Browser: make a new query client if we don't already have one
+  // This is very important, so we don't re-make a new client if React
+  // suspends during the initial render. This may not be needed if we
+  // have a suspense boundary BELOW the creation of the query client
+  if (!browserQueryClient) browserQueryClient = makeQueryClient()
+  return browserQueryClient
+}
+function getUrl() {
+  const base = (() => {
+    if (typeof window !== 'undefined') return ''
+    if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`
+    return 'http://localhost:3000'
+  })()
+  return `${base}/api/trpc`
+}
+export function TRPCReactProvider(
+  props: Readonly<{
+    children: React.ReactNode
+  }>
+) {
+  // NOTE: Avoid useState when initializing the query client if you don't
+  //       have a suspense boundary between this and the code that may
+  //       suspend because React will throw away the client on the initial
+  //       render if it suspends and there is no boundary
+  const queryClient = getQueryClient()
+  const [trpcClient] = useState(() =>
+    createTRPCClient<AppRouter>({
+      links: [
+        httpBatchLink({
+          // transformer: superjson, <-- if you use a data transformer
+          url: getUrl()
+        })
+      ]
+    })
+  )
+  return (
+    <QueryClientProvider client={queryClient}>
+      <TRPCProvider trpcClient={trpcClient} queryClient={queryClient}>
+        {props.children}
+      </TRPCProvider>
+    </QueryClientProvider>
+  )
+}

--- a/src/trpc/init.ts
+++ b/src/trpc/init.ts
@@ -1,0 +1,24 @@
+import { cache } from 'react'
+
+import { initTRPC } from '@trpc/server'
+
+export const createTRPCContext = cache(async () => {
+  /**
+   * @see: https://trpc.io/docs/server/context
+   */
+  return { userId: 'user_123' }
+})
+// Avoid exporting the entire t-object
+// since it's not very descriptive.
+// For instance, the use of a t variable
+// is common in i18n libraries.
+const t = initTRPC.create({
+  /**
+   * @see https://trpc.io/docs/server/data-transformers
+   */
+  // transformer: superjson,
+})
+// Base router and procedure helpers
+export const createTRPCRouter = t.router
+export const createCallerFactory = t.createCallerFactory
+export const baseProcedure = t.procedure

--- a/src/trpc/query-client.ts
+++ b/src/trpc/query-client.ts
@@ -1,0 +1,21 @@
+import { defaultShouldDehydrateQuery, QueryClient } from '@tanstack/react-query'
+
+// import superjson from 'superjson';
+
+export function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 30 * 1000
+      },
+      dehydrate: {
+        // serializeData: superjson.serialize,
+        shouldDehydrateQuery: query =>
+          defaultShouldDehydrateQuery(query) || query.state.status === 'pending'
+      },
+      hydrate: {
+        // deserializeData: superjson.deserialize,
+      }
+    }
+  })
+}

--- a/src/trpc/routers/_app.ts
+++ b/src/trpc/routers/_app.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod'
+
+import { baseProcedure, createTRPCRouter } from '../init'
+
+export const appRouter = createTRPCRouter({
+  hello: baseProcedure
+    .input(
+      z.object({
+        text: z.string()
+      })
+    )
+    .query(opts => {
+      return {
+        greeting: `hello ${opts.input.text}`
+      }
+    })
+})
+
+export type AppRouter = typeof appRouter

--- a/src/trpc/server.tsx
+++ b/src/trpc/server.tsx
@@ -1,0 +1,18 @@
+import { cache } from 'react'
+
+import { createTRPCOptionsProxy } from '@trpc/tanstack-react-query'
+
+import 'server-only' // <-- ensure this file cannot be imported from the client
+
+import { createTRPCContext } from './init'
+import { makeQueryClient } from './query-client'
+import { appRouter } from './routers/_app'
+
+// IMPORTANT: Create a stable getter for the query client that
+//            will return the same client during the same request.
+export const getQueryClient = cache(makeQueryClient)
+export const trpc = createTRPCOptionsProxy({
+  ctx: createTRPCContext,
+  router: appRouter,
+  queryClient: getQueryClient
+})


### PR DESCRIPTION
This pull request introduces tRPC and TanStack React Query into the codebase, setting up a foundation for type-safe API routes and client-server communication. The changes include new dependencies, server and client setup for tRPC, a sample API endpoint, and the integration of React Query and tRPC providers into the app layout. The `HomeView` component is updated to demonstrate fetching data via the new tRPC endpoint.

**tRPC and React Query Integration**

* Added tRPC and TanStack React Query dependencies to `package.json`, including `@tanstack/react-query`, `@trpc/client`, `@trpc/server`, `@trpc/tanstack-react-query`, and related utilities. Downgraded `zod` to a compatible version. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R48-R54) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R71-R75)
* Implemented tRPC server handler at `src/app/api/trpc/[trpc]/route.ts` for API routing. ([src/app/api/trpc/[trpc]/route.tsR1-R13](diffhunk://#diff-fce65859056d89fe5e22c35d68da3be9526781e6efde03a3ad8ebf0f499dd895R1-R13))
* Created tRPC initialization and context setup in `src/trpc/init.ts`, and a base router/procedure helper.
* Added a sample `hello` endpoint in `src/trpc/routers/_app.ts` to demonstrate tRPC usage.

**Client and Provider Setup**

* Created a tRPC React client and provider in `src/trpc/client.tsx`, including logic to manage the React Query client for both server and client environments. [[1]](diffhunk://#diff-0a8942980b250e1103d797a8013f8ded0a799b2ab8cd0fbf3ea8ea3cafa80477R1-R63) [[2]](diffhunk://#diff-65e9cb7ff1c09475a97be86d8d1a33d41c7da105423d5b960e3be69958402037R1-R21)
* Integrated `TRPCReactProvider` into the root layout in `src/app/layout.tsx` to ensure tRPC and React Query context is available throughout the app. [[1]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R4-R5) [[2]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R27-R35)

**Component Refactor**

* Refactored `HomeView` to use the new `useTRPC` and `useQuery` hooks to fetch data from the tRPC `hello` endpoint, replacing the previous authentication-based logic.

**Server Utilities**

* Added `src/trpc/server.tsx` for server-side tRPC helpers, ensuring server-only context and stable query client creation.