### PR TITLE
16: meetings setup

### DIFF
--- a/src/app/(dashboard)/meetings/[meetingId]/page.tsx
+++ b/src/app/(dashboard)/meetings/[meetingId]/page.tsx
@@ -1,0 +1,7 @@
+export default function MeetingIdPage() {
+  return (
+    <div>
+      <h1>MeetingIdPage</h1>
+    </div>
+  )
+}

--- a/src/app/(dashboard)/meetings/page.tsx
+++ b/src/app/(dashboard)/meetings/page.tsx
@@ -1,0 +1,41 @@
+import { Suspense } from 'react'
+
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query'
+import { ErrorBoundary } from 'react-error-boundary'
+
+import { getQueryClient, trpc } from '@/trpc/server'
+
+import { MeetingsView } from '@/modules/meetings/ui/views/meetings-view'
+
+import ErrorState from '@/components/error-state'
+import LoadingState from '@/components/loading-state'
+
+export default function MeetingsPage() {
+  const queryClient = getQueryClient()
+
+  void queryClient.prefetchQuery(trpc.meetings.getMany.queryOptions({}))
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <Suspense
+        fallback={
+          <LoadingState
+            title='Loading Meetings...'
+            description='This may take a moment'
+          />
+        }
+      >
+        <ErrorBoundary
+          fallback={
+            <ErrorState
+              title='Failed to load Meetings'
+              description='Please try again later'
+            />
+          }
+        >
+          <MeetingsView />
+        </ErrorBoundary>
+      </Suspense>
+    </HydrationBoundary>
+  )
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { boolean, pgTable, text, timestamp } from 'drizzle-orm/pg-core'
+import { boolean, pgEnum, pgTable, text, timestamp } from 'drizzle-orm/pg-core'
 import { nanoid } from 'nanoid'
 
 export const user = pgTable('user', {
@@ -70,6 +70,35 @@ export const agents = pgTable('agents', {
     .notNull()
     .references(() => user.id, { onDelete: 'cascade' }),
   instructions: text('instructions').notNull(),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+  updatedAt: timestamp('updated_at').notNull().defaultNow()
+})
+
+export const meetingStatus = pgEnum('meeting_status', [
+  'upcoming',
+  'active',
+  'completed',
+  'processing',
+  'cancelled'
+])
+
+export const meetings = pgTable('meetings', {
+  id: text('id')
+    .primaryKey()
+    .$defaultFn(() => nanoid()),
+  name: text('name').notNull(),
+  userId: text('user_id')
+    .notNull()
+    .references(() => user.id, { onDelete: 'cascade' }),
+  agentId: text('agent_id')
+    .notNull()
+    .references(() => agents.id, { onDelete: 'cascade' }),
+  status: meetingStatus('status').notNull().default('upcoming'),
+  startedAt: timestamp('started_at'),
+  endedAt: timestamp('ended_at'),
+  transcriptUrl: text('transcript_url'),
+  recordingUrl: text('recording_url'),
+  summary: text('summary'),
   createdAt: timestamp('created_at').notNull().defaultNow(),
   updatedAt: timestamp('updated_at').notNull().defaultNow()
 })

--- a/src/modules/agents/server/procedures.ts
+++ b/src/modules/agents/server/procedures.ts
@@ -1,4 +1,13 @@
-import { and, count, desc, eq, getTableColumns, ilike, sql } from 'drizzle-orm'
+import {
+  and,
+  count,
+  desc,
+  eq,
+  getTableColumns,
+  ilike,
+  ne,
+  sql
+} from 'drizzle-orm'
 import { z } from 'zod'
 
 import {
@@ -132,7 +141,7 @@ export const agentsRouter = createTRPCRouter({
           and(
             eq(agents.userId, userId),
             eq(agents.name, input.name),
-            sql`"${agents.id}" <> ${input.id}`
+            ne(agents.id, input.id)
           )
         )
         .limit(1)

--- a/src/modules/meetings/server/procedures.ts
+++ b/src/modules/meetings/server/procedures.ts
@@ -1,0 +1,82 @@
+import { and, count, desc, eq, getTableColumns, ilike } from 'drizzle-orm'
+import { z } from 'zod'
+
+import {
+  DEFAULT_PAGE,
+  DEFAULT_PAGE_SIZE,
+  MAX_PAGE_SIZE,
+  MIN_PAGE_SIZE
+} from '@/constants'
+
+import { db } from '@/db'
+import { meetings } from '@/db/schema'
+import { createTRPCRouter, protectedProcedure } from '@/trpc/init'
+
+export const meetingsRouter = createTRPCRouter({
+  getOne: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .query(async ({ input, ctx }) => {
+      const userId = ctx.session.user.id
+
+      const [existingMeeting] = await db
+        .select({
+          ...getTableColumns(meetings)
+        })
+        .from(meetings)
+        .where(and(eq(meetings.id, input.id), eq(meetings.userId, userId)))
+
+      if (!existingMeeting) {
+        throw new Error('Meeting not found or access denied')
+      }
+
+      return existingMeeting
+    }),
+  getMany: protectedProcedure
+    .input(
+      z.object({
+        page: z.number().min(1).default(DEFAULT_PAGE),
+        pageSize: z
+          .number()
+          .min(MIN_PAGE_SIZE)
+          .max(MAX_PAGE_SIZE)
+          .default(DEFAULT_PAGE_SIZE),
+        search: z.string().nullish()
+      })
+    )
+    .query(async ({ input, ctx }) => {
+      const { page, pageSize, search } = input
+
+      const data = await db
+        .select({
+          ...getTableColumns(meetings)
+        })
+        .from(meetings)
+        .where(
+          and(
+            eq(meetings.userId, ctx.session.user.id),
+            search ? ilike(meetings.name, `%${search}%`) : undefined
+          )
+        )
+        .orderBy(desc(meetings.createdAt), desc(meetings.id))
+        .limit(pageSize)
+        .offset((page - 1) * pageSize)
+
+      const [total] = await db
+        .select({ count: count() })
+        .from(meetings)
+        .where(
+          and(
+            eq(meetings.userId, ctx.session.user.id),
+            search ? ilike(meetings.name, `%${search}%`) : undefined
+          )
+        )
+
+      const totalPages = Math.ceil(total.count / pageSize)
+
+      return {
+        items: data,
+        total: total.count,
+        totalPages
+      }
+    })
+})

--- a/src/modules/meetings/ui/views/meetings-view.tsx
+++ b/src/modules/meetings/ui/views/meetings-view.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import { useSuspenseQuery } from '@tanstack/react-query'
+
+import { useTRPC } from '@/trpc/client'
+
+const MeetingsView = () => {
+  const trpc = useTRPC()
+  const { data } = useSuspenseQuery(trpc.meetings.getMany.queryOptions({}))
+
+  return <div>{JSON.stringify(data)}</div>
+}
+
+export { MeetingsView }

--- a/src/trpc/routers/_app.ts
+++ b/src/trpc/routers/_app.ts
@@ -1,9 +1,11 @@
 import { agentsRouter } from '@/modules/agents/server/procedures'
+import { meetingsRouter } from '@/modules/meetings/server/procedures'
 
 import { createTRPCRouter } from '../init'
 
 export const appRouter = createTRPCRouter({
-  agents: agentsRouter
+  agents: agentsRouter,
+  meetings: meetingsRouter
 })
 
 export type AppRouter = typeof appRouter


### PR DESCRIPTION
This pull request introduces the initial implementation of meetings functionality, including database schema changes, backend API endpoints, and frontend integration for listing meetings. The main themes are database schema expansion, API development, and frontend wiring.

**Database schema and backend API:**

* Added a new `meetingStatus` enum and a `meetings` table to the database schema, supporting fields such as `name`, `userId`, `agentId`, `status`, timestamps, and optional fields for transcript, recording, and summary.
* Implemented the `meetingsRouter` in the backend, providing protected procedures for fetching a single meeting (`getOne`) and paginated meeting lists with search support (`getMany`).
* Registered the new `meetingsRouter` in the main TRPC app router for API access.

**Frontend integration:**

* Created a new meetings page (`meetings/page.tsx`) that uses React Query and TRPC to fetch and display meetings, with loading and error handling states.
* Added a `MeetingsView` component that consumes the meetings data and renders it (currently as JSON for initial development).
* Added a placeholder page for individual meetings (`meetings/[meetingId]/page.tsx`). ([src/app/(dashboard)/meetings/[meetingId]/page.tsxR1-R7](diffhunk://#diff-fc346d8a856bbeb1d0e4184809ddf678643527a6625006a2b024807f7430976cR1-R7))

**Miscellaneous improvements:**

* Refactored agent update validation to use the `ne` (not equal) operator from Drizzle ORM for improved clarity.
* Minor import updates to support new features. [[1]](diffhunk://#diff-4bccf0a85960664570150bcf86a66e64e825b88f02fe19c2e323e96f65e2d55fL1-R1) [[2]](diffhunk://#diff-1f6f283869399c9effc1b7d17b62b743281d7a2f1c2dcad776e843e0962557bdL1-R10)