### PR TITLE
19: meetings filters

### DIFF
--- a/src/app/(dashboard)/meetings/page.tsx
+++ b/src/app/(dashboard)/meetings/page.tsx
@@ -4,18 +4,28 @@ import { headers } from 'next/headers'
 import { redirect } from 'next/navigation'
 
 import { dehydrate, HydrationBoundary } from '@tanstack/react-query'
+import { SearchParams } from 'nuqs/server'
 import { ErrorBoundary } from 'react-error-boundary'
 
 import { getQueryClient, trpc } from '@/trpc/server'
 import { auth } from '@/lib/auth'
 
+import { loadSearchParams } from '@/modules/meetings/params'
 import { MeetingsListHeader } from '@/modules/meetings/ui/components/meetings-list-header'
 import { MeetingsView } from '@/modules/meetings/ui/views/meetings-view'
 
 import ErrorState from '@/components/error-state'
 import LoadingState from '@/components/loading-state'
 
-export default async function MeetingsPage() {
+interface MeetingsPageProps {
+  searchParams: Promise<SearchParams>
+}
+
+export default async function MeetingsPage({
+  searchParams
+}: MeetingsPageProps) {
+  const params = await loadSearchParams(searchParams)
+
   const session = await auth.api.getSession({
     headers: await headers()
   })
@@ -24,7 +34,11 @@ export default async function MeetingsPage() {
 
   const queryClient = getQueryClient()
 
-  void queryClient.prefetchQuery(trpc.meetings.getMany.queryOptions({}))
+  void queryClient.prefetchQuery(
+    trpc.meetings.getMany.queryOptions({
+      ...params
+    })
+  )
 
   return (
     <>

--- a/src/components/command-select.tsx
+++ b/src/components/command-select.tsx
@@ -42,6 +42,11 @@ const CommandSelect = ({
 
   const selectedOption = options.find(option => option.value === value)
 
+  const handleOpenChange = (open: boolean) => {
+    onSearch?.('')
+    setOpen(open)
+  }
+
   return (
     <>
       <Button
@@ -60,7 +65,7 @@ const CommandSelect = ({
 
       <CommandResponsiveDialog
         open={open}
-        onOpenChange={setOpen}
+        onOpenChange={handleOpenChange}
         shouldFilter={!onSearch}
       >
         <CommandInput placeholder='Search...' onValueChange={onSearch} />

--- a/src/components/data-pagination.tsx
+++ b/src/components/data-pagination.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+
+interface DataPaginationProps {
+  page: number
+  totalPages: number
+  onPageChange: (page: number) => void
+}
+
+const DataPagination = ({
+  page,
+  totalPages,
+  onPageChange
+}: DataPaginationProps) => {
+  return (
+    <div className='flex items-center justify-between'>
+      <div className='text-muted-foreground flex-1 text-sm md:text-xs'>
+        {`Page ${page} of ${totalPages || 1}`}
+      </div>
+
+      <div className='flex items-center justify-end space-x-2 py-4'>
+        <Button
+          disabled={page <= 1 || totalPages === 0}
+          variant='outline'
+          size='sm'
+          onClick={() => onPageChange(Math.max(1, page - 1))}
+        >
+          Previous
+        </Button>
+        <Button
+          disabled={page >= totalPages || totalPages === 0}
+          variant='outline'
+          size='sm'
+          onClick={() => onPageChange(Math.min(totalPages, page + 1))}
+        >
+          Next
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export { DataPagination }

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -6,7 +6,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const badgeVariants = cva(
-  'focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-md border px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] [&>svg]:pointer-events-none [&>svg]:size-3',
+  'focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-md border px-2 py-1 text-xs font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] [&>svg]:pointer-events-none [&>svg]:size-3',
   {
     variants: {
       variant: {

--- a/src/hooks/use-meetings-filters.ts
+++ b/src/hooks/use-meetings-filters.ts
@@ -1,0 +1,21 @@
+import {
+  parseAsInteger,
+  parseAsString,
+  parseAsStringEnum,
+  useQueryStates
+} from 'nuqs'
+
+import { DEFAULT_PAGE } from '@/constants'
+
+import { MeetingStatus } from '@/modules/meetings/types'
+
+export const useMeetingsFilters = () => {
+  return useQueryStates({
+    page: parseAsInteger
+      .withDefault(DEFAULT_PAGE)
+      .withOptions({ clearOnDefault: true }),
+    search: parseAsString.withDefault('').withOptions({ clearOnDefault: true }),
+    status: parseAsStringEnum(Object.values(MeetingStatus)),
+    agentId: parseAsString.withDefault('').withOptions({ clearOnDefault: true })
+  })
+}

--- a/src/modules/agents/ui/components/agents-list-header.tsx
+++ b/src/modules/agents/ui/components/agents-list-header.tsx
@@ -9,6 +9,7 @@ import { DEFAULT_PAGE } from '@/constants'
 import { useAgentsFilters } from '@/hooks/use-agents-filters'
 
 import { Button } from '@/components/ui/button'
+import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area'
 
 import { AgentsSearchFilter } from './agents-search-filter'
 import NewAgentDialog from './new-agent-dialog'
@@ -40,15 +41,19 @@ const AgentsListHeader = () => {
           </Button>
         </div>
 
-        <div className='flex items-center gap-x-2 p-1'>
-          <AgentsSearchFilter />
-          {isAnyFilterApplied && (
-            <Button variant='outline' size='sm' onClick={onClearFilters}>
-              <XCircleIcon />
-              Clear
-            </Button>
-          )}
-        </div>
+        <ScrollArea>
+          <div className='flex items-center gap-x-2 p-1'>
+            <AgentsSearchFilter />
+            {isAnyFilterApplied && (
+              <Button variant='outline' size='sm' onClick={onClearFilters}>
+                <XCircleIcon />
+                Clear
+              </Button>
+            )}
+          </div>
+
+          <ScrollBar orientation='horizontal' />
+        </ScrollArea>
       </div>
     </>
   )

--- a/src/modules/meetings/params.ts
+++ b/src/modules/meetings/params.ts
@@ -1,0 +1,21 @@
+import {
+  createLoader,
+  parseAsInteger,
+  parseAsString,
+  parseAsStringEnum
+} from 'nuqs/server'
+
+import { DEFAULT_PAGE } from '@/constants'
+
+import { MeetingStatus } from './types'
+
+export const filterSearchParams = {
+  page: parseAsInteger
+    .withDefault(DEFAULT_PAGE)
+    .withOptions({ clearOnDefault: true }),
+  search: parseAsString.withDefault('').withOptions({ clearOnDefault: true }),
+  status: parseAsStringEnum(Object.values(MeetingStatus)),
+  agentId: parseAsString.withDefault('').withOptions({ clearOnDefault: true })
+}
+
+export const loadSearchParams = createLoader(filterSearchParams)

--- a/src/modules/meetings/types.ts
+++ b/src/modules/meetings/types.ts
@@ -5,3 +5,10 @@ import type { AppRouter } from '@/trpc/routers/_app'
 export type MeetingGetOne = inferRouterOutputs<AppRouter>['meetings']['getOne']
 export type MeetingGetMany =
   inferRouterOutputs<AppRouter>['meetings']['getMany']['items']
+export enum MeetingStatus {
+  Upcoming = 'upcoming',
+  Active = 'active',
+  Completed = 'completed',
+  Processing = 'processing',
+  Cancelled = 'cancelled'
+}

--- a/src/modules/meetings/ui/components/agent-id-filter.tsx
+++ b/src/modules/meetings/ui/components/agent-id-filter.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react'
+
+import { useQuery } from '@tanstack/react-query'
+
+import { useTRPC } from '@/trpc/client'
+import { useMeetingsFilters } from '@/hooks/use-meetings-filters'
+
+import CommandSelect from '@/components/command-select'
+import { GeneratedAvatar } from '@/components/generated-avatar'
+
+const AgentIdFilter = () => {
+  const [filters, setFilters] = useMeetingsFilters()
+
+  const trpc = useTRPC()
+
+  const [agentSearch, setAgentSearch] = useState('')
+
+  const { data } = useQuery(
+    trpc.agents.getMany.queryOptions({
+      pageSize: 100,
+      search: agentSearch
+    })
+  )
+
+  return (
+    <CommandSelect
+      className='h-9'
+      placeholder='Filter by Agent'
+      options={(data?.items ?? []).map(agent => ({
+        id: agent.id,
+        value: agent.id,
+        children: (
+          <div className='flex items-center gap-x-2'>
+            <GeneratedAvatar
+              variant='botttsNeutral'
+              seed={agent.name}
+              className='size-4'
+            />
+            {agent.name}
+          </div>
+        )
+      }))}
+      onSelect={value => setFilters({ agentId: value })}
+      onSearch={setAgentSearch}
+      value={filters.agentId ?? ''}
+    />
+  )
+}
+
+export { AgentIdFilter }

--- a/src/modules/meetings/ui/components/meeting-form.tsx
+++ b/src/modules/meetings/ui/components/meeting-form.tsx
@@ -148,7 +148,7 @@ const MeetingForm = ({
             control={form.control}
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Agent Name</FormLabel>
+                <FormLabel>Meeting Name</FormLabel>
                 <FormControl>
                   <Input
                     placeholder='e.g. "Math consultations"'

--- a/src/modules/meetings/ui/components/meetings-list-header.tsx
+++ b/src/modules/meetings/ui/components/meetings-list-header.tsx
@@ -2,14 +2,40 @@
 
 import { useState } from 'react'
 
-import { PlusIcon } from 'lucide-react'
+import { PlusIcon, XCircleIcon } from 'lucide-react'
+
+import { DEFAULT_PAGE } from '@/constants'
+
+import { useMeetingsFilters } from '@/hooks/use-meetings-filters'
 
 import { Button } from '@/components/ui/button'
+import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area'
 
+import { AgentIdFilter } from './agent-id-filter'
+import { MeetingsSearchFilter } from './meetings-search-filter'
 import NewMeetingDialog from './new-meeting-dialog'
+import { StatusFilter } from './status-filter'
 
 const MeetingsListHeader = () => {
   const [isDialogOpen, setIsDialogOpen] = useState(false)
+
+  const [filters, setFilters] = useMeetingsFilters()
+
+  const isAnyFilterApplied = !!(
+    filters.agentId ||
+    filters.status ||
+    filters.search
+  )
+
+  const onClearFilters = () => {
+    setFilters({
+      status: null,
+      agentId: '',
+      search: '',
+      page: DEFAULT_PAGE
+    })
+  }
+
   return (
     <>
       <NewMeetingDialog open={isDialogOpen} onOpenChange={setIsDialogOpen} />
@@ -26,7 +52,22 @@ const MeetingsListHeader = () => {
           </Button>
         </div>
 
-        <div className='flex items-center gap-x-2 p-1'>todo: filters</div>
+        <ScrollArea>
+          <div className='flex items-center gap-x-2 p-1'>
+            <MeetingsSearchFilter />
+            <StatusFilter />
+            <AgentIdFilter />
+
+            {isAnyFilterApplied && (
+              <Button variant='outline' size='sm' onClick={onClearFilters}>
+                <XCircleIcon className='size-4' />
+                Clear
+              </Button>
+            )}
+          </div>
+
+          <ScrollBar orientation='horizontal' />
+        </ScrollArea>
       </div>
     </>
   )

--- a/src/modules/meetings/ui/components/meetings-search-filter.tsx
+++ b/src/modules/meetings/ui/components/meetings-search-filter.tsx
@@ -41,7 +41,7 @@ const MeetingsSearchFilter = () => {
   return (
     <div className='relative'>
       <Input
-        placeholder='Search agents...'
+        placeholder='Search meetings...'
         className='h-9 w-[200px] bg-white pl-7'
         value={localSearch}
         onChange={handleSearchChange}

--- a/src/modules/meetings/ui/components/meetings-search-filter.tsx
+++ b/src/modules/meetings/ui/components/meetings-search-filter.tsx
@@ -6,12 +6,12 @@ import { SearchIcon } from 'lucide-react'
 
 import debounce from 'debounce'
 
-import { useAgentsFilters } from '@/hooks/use-agents-filters'
+import { useMeetingsFilters } from '@/hooks/use-meetings-filters'
 
 import { Input } from '@/components/ui/input'
 
-const AgentsSearchFilter = () => {
-  const [filters, setFilters] = useAgentsFilters()
+const MeetingsSearchFilter = () => {
+  const [filters, setFilters] = useMeetingsFilters()
   const [localSearch, setLocalSearch] = useState(filters.search)
 
   useEffect(() => {
@@ -51,4 +51,4 @@ const AgentsSearchFilter = () => {
   )
 }
 
-export { AgentsSearchFilter }
+export { MeetingsSearchFilter }

--- a/src/modules/meetings/ui/components/status-filter.tsx
+++ b/src/modules/meetings/ui/components/status-filter.tsx
@@ -1,0 +1,84 @@
+import {
+  CircleCheckIcon,
+  CircleXIcon,
+  ClockArrowUpIcon,
+  LoaderIcon,
+  VideoIcon
+} from 'lucide-react'
+
+import { useMeetingsFilters } from '@/hooks/use-meetings-filters'
+
+import CommandSelect from '@/components/command-select'
+
+import { MeetingStatus } from '../../types'
+
+const options = [
+  {
+    id: MeetingStatus.Upcoming,
+    value: MeetingStatus.Upcoming,
+    children: (
+      <div className='flex items-center gap-x-2 capitalize'>
+        <ClockArrowUpIcon className='stroke-[2.5]' />
+        Upcoming
+      </div>
+    )
+  },
+  {
+    id: MeetingStatus.Completed,
+    value: MeetingStatus.Completed,
+    children: (
+      <div className='flex items-center gap-x-2 capitalize'>
+        <CircleCheckIcon className='stroke-[2.5]' />
+        Completed
+      </div>
+    )
+  },
+  {
+    id: MeetingStatus.Active,
+    value: MeetingStatus.Active,
+    children: (
+      <div className='flex items-center gap-x-2 capitalize'>
+        <VideoIcon className='stroke-[2.5]' />
+        Active
+      </div>
+    )
+  },
+  {
+    id: MeetingStatus.Processing,
+    value: MeetingStatus.Processing,
+    children: (
+      <div className='flex items-center gap-x-2 capitalize'>
+        <LoaderIcon className='stroke-[2.5]' />
+        Processing
+      </div>
+    )
+  },
+  {
+    id: MeetingStatus.Cancelled,
+    value: MeetingStatus.Cancelled,
+    children: (
+      <div className='flex items-center gap-x-2 capitalize'>
+        <CircleXIcon className='stroke-[2.5]' />
+        Canceled
+      </div>
+    )
+  }
+]
+
+const StatusFilter = () => {
+  const [filters, setFilters] = useMeetingsFilters()
+
+  return (
+    <CommandSelect
+      placeholder='Filter by status'
+      className='h-9'
+      options={options}
+      onSelect={(value: string) =>
+        setFilters({ status: value as MeetingStatus })
+      }
+      value={filters.status ?? ''}
+    />
+  )
+}
+
+export { StatusFilter }

--- a/src/modules/meetings/ui/components/status-filter.tsx
+++ b/src/modules/meetings/ui/components/status-filter.tsx
@@ -59,7 +59,7 @@ const options = [
     children: (
       <div className='flex items-center gap-x-2 capitalize'>
         <CircleXIcon className='stroke-[2.5]' />
-        Canceled
+        Cancelled
       </div>
     )
   }

--- a/src/modules/meetings/ui/views/meetings-view.tsx
+++ b/src/modules/meetings/ui/views/meetings-view.tsx
@@ -1,21 +1,42 @@
 'use client'
 
+import { useRouter } from 'next/navigation'
+
 import { useSuspenseQuery } from '@tanstack/react-query'
 
 import { useTRPC } from '@/trpc/client'
+import { useMeetingsFilters } from '@/hooks/use-meetings-filters'
 
+import { DataPagination } from '@/components/data-pagination'
 import { DataTable } from '@/components/data-table'
 import EmptyState from '@/components/empty-state'
 
 import { columns } from '../components/columns'
 
 const MeetingsView = () => {
+  const router = useRouter()
+
+  const [filters, setFilter] = useMeetingsFilters()
+
   const trpc = useTRPC()
-  const { data } = useSuspenseQuery(trpc.meetings.getMany.queryOptions({}))
+  const { data } = useSuspenseQuery(
+    trpc.meetings.getMany.queryOptions({
+      ...filters
+    })
+  )
 
   return (
     <div className='flex flex-1 flex-col gap-y-4 px-4 pb-4 md:px-8'>
-      <DataTable data={data.items} columns={columns} />
+      <DataTable
+        data={data.items}
+        columns={columns}
+        onRowClick={row => router.push(`/meetings/${row.id}`)}
+      />
+      <DataPagination
+        page={filters.page}
+        totalPages={data.totalPages}
+        onPageChange={page => setFilter({ page })}
+      />
 
       {data.items.length === 0 && (
         <EmptyState


### PR DESCRIPTION
This pull request introduces a comprehensive set of improvements to the meetings dashboard, adding advanced filtering capabilities, pagination, and several UI enhancements. The main focus is on enabling users to filter meetings by search, status, and agent, as well as providing a more interactive and user-friendly experience when browsing and managing meetings.

**Meetings Filtering and Query Improvements**

* Added a reusable `useMeetingsFilters` hook and supporting utilities to manage meetings filters (search, status, agentId, and page) via URL query parameters, using the `nuqs` library for parsing and state management. [[1]](diffhunk://#diff-80fd36792e03bf870cc4ba0d1bae8b74ce1beb027960c219f39dd93940247141R1-R21) [[2]](diffhunk://#diff-aa10bf74375eae5235e506af2216ca2f91bb78b9360e1df4c0c23470b49c9861R1-R21)
* Updated the meetings TRPC backend procedure and types to support filtering by status and agentId, in addition to search and pagination. This includes a new `MeetingStatus` enum and expanded query logic. [[1]](diffhunk://#diff-f53f195005c0d499864c12b30278fb33e605307a5c0b38d34e247e26e0c50c2fR16) [[2]](diffhunk://#diff-f53f195005c0d499864c12b30278fb33e605307a5c0b38d34e247e26e0c50c2fL45-R66) [[3]](diffhunk://#diff-f53f195005c0d499864c12b30278fb33e605307a5c0b38d34e247e26e0c50c2fL69-R81) [[4]](diffhunk://#diff-f53f195005c0d499864c12b30278fb33e605307a5c0b38d34e247e26e0c50c2fL83-R97) [[5]](diffhunk://#diff-44b70a3834728033682b091cb91a72decba19b13b37f40f7de22ed415ca3e45dR8-R14)

**UI Enhancements and New Components**

* Implemented new filter UI components: `MeetingsSearchFilter`, `StatusFilter`, and `AgentIdFilter`, all integrated into the meetings list header for a seamless filtering experience. Added a "Clear" button to reset all filters. [[1]](diffhunk://#diff-84e13fe835dc34e8b106cc0a6f6b62caf57526843d00a6c137c043bafb172776L5-R38) [[2]](diffhunk://#diff-84e13fe835dc34e8b106cc0a6f6b62caf57526843d00a6c137c043bafb172776L29-R70) [[3]](diffhunk://#diff-7a12123de7e0c4784f93abdb6a23340836feb89e7339701d41ea08856461b965R1-R54) [[4]](diffhunk://#diff-7bcf3d160514fceec87bad237f203c2e13060299967177341710c11b42337a8eR1-R84) [[5]](diffhunk://#diff-9ab5b67912561969dbb7c2348e8c1f72c210acba8b3fb7633ead2d3287929bc9R1-R50)
* Added a `DataPagination` component and integrated it into the meetings view, allowing users to navigate between pages of meetings. [[1]](diffhunk://#diff-cb25fc5773cadb8a8d6e8f3ddb1529885c2b7227d305e7469fca2935b05b32d7R1-R44) [[2]](diffhunk://#diff-d4eb9e7626f59cd72ead21294bd996cba6a4294eb0245860f28bb4c052e34534R3-R39)

**General UX and Code Quality Improvements**

* Enhanced filter controls with scrollable areas to improve usability when multiple filters are present, both in meetings and agents list headers. [[1]](diffhunk://#diff-84e13fe835dc34e8b106cc0a6f6b62caf57526843d00a6c137c043bafb172776L29-R70) [[2]](diffhunk://#diff-656af9bb19bec16d49f6ee2f1045c57e49d4183c878886c93c7358d32d84db91R44) [[3]](diffhunk://#diff-656af9bb19bec16d49f6ee2f1045c57e49d4183c878886c93c7358d32d84db91R54-R56)
* Improved the `CommandSelect` component to clear the search input when the dropdown is closed, ensuring a smoother user experience. [[1]](diffhunk://#diff-009fee961f27029ea3a11def0b48fee212282c37eb93b9ba60e0988455a366efR45-R49) [[2]](diffhunk://#diff-009fee961f27029ea3a11def0b48fee212282c37eb93b9ba60e0988455a366efL63-R68)
* Fixed a label typo in the meeting form ("Agent Name" → "Meeting Name").
* Minor UI tweaks, such as adjusting badge padding for better visual consistency.

**Performance and Cleanup**

* Debounced search filter updates and ensured cleanup of debounce timers in both agents and meetings search filters to prevent memory leaks. [[1]](diffhunk://#diff-deac1b1fa00b6643fe4c4a02dd10b1b66264f59234efa5f9e36338e785237306R29-R34) [[2]](diffhunk://#diff-7a12123de7e0c4784f93abdb6a23340836feb89e7339701d41ea08856461b965R1-R54)

These changes collectively provide a much more powerful and user-friendly meetings dashboard, with robust filtering, pagination, and improved code maintainability.