### PR TITLE
21: meeting variants

### DIFF
--- a/public/cancelled.svg
+++ b/public/cancelled.svg
@@ -1,0 +1,48 @@
+<svg width="166" height="135" viewBox="12 0 166 135" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="94.5" cy="67.5" r="59.5" fill="#F5F6F6"/>
+<g filter="url(#filter0_d)">
+  <rect x="22" y="26" width="145" height="72" rx="6" fill="white"/>
+  <rect x="22.25" y="26.25" width="144.5" height="71.5" rx="5.75" stroke="#E9F7F0" stroke-width="0.5"/>
+</g>
+<g filter="url(#filter1_dd)">
+  <rect x="12" y="37" width="166" height="50" rx="8" fill="white"/>
+  <rect x="12.25" y="37.25" width="165.5" height="49.5" rx="7.75" stroke="#E9F7F0" stroke-width="0.5"/>
+</g>
+
+<!-- Light gray background box -->
+<rect x="20" y="45" width="34" height="34" rx="6" fill="#F5F6F6"/>
+
+<!-- Cancelled Icon (Circle with X inside) -->
+<circle cx="37" cy="62" r="8" fill="#EDF3F3"/>
+<path d="M33.5 58.5L40.5 65.5" stroke="#B0B3B2" stroke-width="1.5" stroke-linecap="round"/>
+<path d="M40.5 58.5L33.5 65.5" stroke="#B0B3B2" stroke-width="1.5" stroke-linecap="round"/>
+
+<!-- Lines -->
+<rect x="63" y="49" width="72" height="4" rx="2" fill="#17A34A"/>
+<rect x="63" y="61" width="64" height="4" rx="2" fill="#D5F2E0"/>
+<rect x="63" y="73" width="94" height="4" rx="2" fill="#E9F7F0"/>
+
+<defs>
+  <filter id="filter0_d" x="20.125" y="25.0625" width="148.75" height="75.75" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+    <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+    <feGaussianBlur stdDeviation="1"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.1 0 0 0 0 0.15 0 0 0 0 0.14 0 0 0 0.04 0"/>
+    <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+    <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+  </filter>
+  <filter id="filter1_dd" x="0" y="37" width="190" height="73" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+    <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+    <feMorphology radius="2" operator="erode" in="SourceAlpha" result="effect1_dropShadow"/>
+    <feOffset dy="4"/>
+    <feGaussianBlur stdDeviation="3"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.1 0 0 0 0 0.15 0 0 0 0 0.14 0 0 0 0.05 0"/>
+    <feBlend mode="normal" in2="effect1_dropShadow" result="effect1_dropShadow"/>
+    <feMorphology radius="4" operator="erode" in="SourceAlpha" result="effect2_dropShadow"/>
+    <feOffset dy="12"/>
+    <feGaussianBlur stdDeviation="8"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.1 0 0 0 0 0.15 0 0 0 0 0.14 0 0 0 0.07 0"/>
+    <feBlend mode="normal" in2="effect2_dropShadow" result="effect2_dropShadow"/>
+    <feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow" result="shape"/>
+  </filter>
+</defs>
+</svg>

--- a/public/processing.svg
+++ b/public/processing.svg
@@ -1,0 +1,46 @@
+<svg width="166" height="135" viewBox="12 0 166 135" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="94.5" cy="67.5" r="59.5" fill="#F5F6F6"/>
+<g filter="url(#filter0_d)">
+  <rect x="22" y="26" width="145" height="72" rx="6" fill="white"/>
+  <rect x="22.25" y="26.25" width="144.5" height="71.5" rx="5.75" stroke="#E9F7F0" stroke-width="0.5"/>
+</g>
+<g filter="url(#filter1_dd)">
+  <rect x="12" y="37" width="166" height="50" rx="8" fill="white"/>
+  <rect x="12.25" y="37.25" width="165.5" height="49.5" rx="7.75" stroke="#E9F7F0" stroke-width="0.5"/>
+</g>
+
+<!-- Light gray background box -->
+<rect x="20" y="45" width="34" height="34" rx="6" fill="#F5F6F6"/>
+
+<!-- Premium Centered Checkmark -->
+<path d="M32 62L36 66L43 57" stroke="#B0B3B2" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+
+<!-- Lines -->
+<rect x="63" y="49" width="72" height="4" rx="2" fill="#17A34A"/>
+<rect x="63" y="61" width="64" height="4" rx="2" fill="#D5F2E0"/>
+<rect x="63" y="73" width="94" height="4" rx="2" fill="#E9F7F0"/>
+
+<defs>
+  <filter id="filter0_d" x="20.125" y="25.0625" width="148.75" height="75.75" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+    <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+    <feGaussianBlur stdDeviation="1"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.1 0 0 0 0 0.15 0 0 0 0 0.14 0 0 0 0.04 0"/>
+    <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+    <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+  </filter>
+  <filter id="filter1_dd" x="0" y="37" width="190" height="73" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+    <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+    <feMorphology radius="2" operator="erode" in="SourceAlpha" result="effect1_dropShadow"/>
+    <feOffset dy="4"/>
+    <feGaussianBlur stdDeviation="3"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.1 0 0 0 0 0.15 0 0 0 0 0.14 0 0 0 0.05 0"/>
+    <feBlend mode="normal" in2="effect1_dropShadow" result="effect1_dropShadow"/>
+    <feMorphology radius="4" operator="erode" in="SourceAlpha" result="effect2_dropShadow"/>
+    <feOffset dy="12"/>
+    <feGaussianBlur stdDeviation="8"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.1 0 0 0 0 0.15 0 0 0 0 0.14 0 0 0 0.07 0"/>
+    <feBlend mode="normal" in2="effect2_dropShadow" result="effect2_dropShadow"/>
+    <feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow" result="shape"/>
+  </filter>
+</defs>
+</svg>

--- a/public/upcoming.svg
+++ b/public/upcoming.svg
@@ -1,0 +1,47 @@
+<svg width="166" height="135" viewBox="12 0 166 135" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="94.5" cy="67.5" r="59.5" fill="#F5F6F6"/>
+<g filter="url(#filter0_d)">
+  <rect x="22" y="26" width="145" height="72" rx="6" fill="white"/>
+  <rect x="22.25" y="26.25" width="144.5" height="71.5" rx="5.75" stroke="#E9F7F0" stroke-width="0.5"/>
+</g>
+<g filter="url(#filter1_dd)">
+  <rect x="12" y="37" width="166" height="50" rx="8" fill="white"/>
+  <rect x="12.25" y="37.25" width="165.5" height="49.5" rx="7.75" stroke="#E9F7F0" stroke-width="0.5"/>
+</g>
+
+<!-- Light gray background box -->
+<rect x="20" y="45" width="34" height="34" rx="6" fill="#F5F6F6"/>
+
+<!-- Perfectly Centered Video Camera Icon -->
+<rect x="28.5" y="56" width="13" height="10" rx="2" fill="#B0B3B2"/>
+<path d="M41.5 58L45.5 56V66L41.5 64V58Z" fill="#B0B3B2"/>
+
+<!-- Lines -->
+<rect x="63" y="49" width="72" height="4" rx="2" fill="#17A34A"/>
+<rect x="63" y="61" width="64" height="4" rx="2" fill="#D5F2E0"/>
+<rect x="63" y="73" width="94" height="4" rx="2" fill="#E9F7F0"/>
+
+<defs>
+  <filter id="filter0_d" x="20.125" y="25.0625" width="148.75" height="75.75" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+    <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+    <feGaussianBlur stdDeviation="1"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.1 0 0 0 0 0.15 0 0 0 0 0.14 0 0 0 0.04 0"/>
+    <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+    <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+  </filter>
+  <filter id="filter1_dd" x="0" y="37" width="190" height="73" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+    <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+    <feMorphology radius="2" operator="erode" in="SourceAlpha" result="effect1_dropShadow"/>
+    <feOffset dy="4"/>
+    <feGaussianBlur stdDeviation="3"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.1 0 0 0 0 0.15 0 0 0 0 0.14 0 0 0 0.05 0"/>
+    <feBlend mode="normal" in2="effect1_dropShadow" result="effect1_dropShadow"/>
+    <feMorphology radius="4" operator="erode" in="SourceAlpha" result="effect2_dropShadow"/>
+    <feOffset dy="12"/>
+    <feGaussianBlur stdDeviation="8"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.1 0 0 0 0 0.15 0 0 0 0 0.14 0 0 0 0.07 0"/>
+    <feBlend mode="normal" in2="effect2_dropShadow" result="effect2_dropShadow"/>
+    <feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow" result="shape"/>
+  </filter>
+</defs>
+</svg>

--- a/src/components/empty-state.tsx
+++ b/src/components/empty-state.tsx
@@ -3,13 +3,18 @@ import Image from 'next/image'
 interface ErrorStateProps {
   title: string
   description: string
+  image?: string
 }
 
-const EmptyState = ({ title, description }: ErrorStateProps) => {
+const EmptyState = ({
+  title,
+  description,
+  image = '/empty.svg'
+}: ErrorStateProps) => {
   return (
     <div className='flex flex-col items-center justify-center px-8 py-4'>
       <Image
-        src='/empty.svg'
+        src={image}
         alt='Empty State placeholder'
         width={240}
         height={240}

--- a/src/modules/meetings/ui/components/active-state.tsx
+++ b/src/modules/meetings/ui/components/active-state.tsx
@@ -1,0 +1,33 @@
+import Link from 'next/link'
+
+import { VideoIcon } from 'lucide-react'
+
+import EmptyState from '@/components/empty-state'
+import { Button } from '@/components/ui/button'
+
+interface ActiveStateProps {
+  meetingId: string
+}
+
+const ActiveState = ({ meetingId }: ActiveStateProps) => {
+  return (
+    <div className='flex flex-col items-center justify-center gap-y-8 rounded-lg bg-white px-4 py-5'>
+      <EmptyState
+        title='Your meeting is active!'
+        description='Meeting will end once all participants leave.'
+        image='/upcoming.svg'
+      />
+
+      <div className='flex w-full flex-col-reverse items-center gap-2 lg:flex-row lg:justify-center'>
+        <Button asChild className='w-full lg:w-auto'>
+          <Link href={`/call/${meetingId}`}>
+            <VideoIcon className='size-4' />
+            <span>Join Meeting</span>
+          </Link>
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export { ActiveState }

--- a/src/modules/meetings/ui/components/cancelled-state.tsx
+++ b/src/modules/meetings/ui/components/cancelled-state.tsx
@@ -1,0 +1,15 @@
+import EmptyState from '@/components/empty-state'
+
+const CancelledState = () => {
+  return (
+    <div className='flex flex-col items-center justify-center gap-y-8 rounded-lg bg-white px-4 py-5'>
+      <EmptyState
+        title='Your meeting is cancelled'
+        description='Meeting cannot be resumed once cancelled.'
+        image='/cancelled.svg'
+      />
+    </div>
+  )
+}
+
+export { CancelledState }

--- a/src/modules/meetings/ui/components/processing-state.tsx
+++ b/src/modules/meetings/ui/components/processing-state.tsx
@@ -1,0 +1,15 @@
+import EmptyState from '@/components/empty-state'
+
+const ProcessingState = () => {
+  return (
+    <div className='flex flex-col items-center justify-center gap-y-8 rounded-lg bg-white px-4 py-5'>
+      <EmptyState
+        title='Your meeting has been successfully completed!'
+        description='Meeting is currently being processed, a summary will be available shortly. '
+        image='/processing.svg'
+      />
+    </div>
+  )
+}
+
+export { ProcessingState }

--- a/src/modules/meetings/ui/components/upcoming-state.tsx
+++ b/src/modules/meetings/ui/components/upcoming-state.tsx
@@ -1,0 +1,48 @@
+import Link from 'next/link'
+
+import { BanIcon, VideoIcon } from 'lucide-react'
+
+import EmptyState from '@/components/empty-state'
+import { Button } from '@/components/ui/button'
+
+interface UpcomingStateProps {
+  meetingId: string
+  onCancelMeeting: () => void
+  isCancelling: boolean
+}
+
+const UpcomingState = ({
+  meetingId,
+  onCancelMeeting,
+  isCancelling
+}: UpcomingStateProps) => {
+  return (
+    <div className='flex flex-col items-center justify-center gap-y-8 rounded-lg bg-white px-4 py-5'>
+      <EmptyState
+        title='Your meeting is scheduled!'
+        description='Once you start this meeting, a summary will be generated here.'
+        image='/upcoming.svg'
+      />
+
+      <div className='flex w-full flex-col-reverse items-center gap-2 lg:flex-row lg:justify-center'>
+        <Button
+          variant='secondary'
+          className='w-full lg:w-auto'
+          onClick={onCancelMeeting}
+          disabled={isCancelling}
+        >
+          <BanIcon className='size-4' />
+          <span>Cancel Meeting</span>
+        </Button>
+        <Button asChild className='w-full lg:w-auto' disabled={isCancelling}>
+          <Link href={`/call/${meetingId}`}>
+            <VideoIcon className='size-4' />
+            <span>Start Meeting</span>
+          </Link>
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export { UpcomingState }

--- a/src/modules/meetings/ui/views/meeting-id-view.tsx
+++ b/src/modules/meetings/ui/views/meeting-id-view.tsx
@@ -14,7 +14,11 @@ import { toast } from 'sonner'
 import { useTRPC } from '@/trpc/client'
 import { useConfirm } from '@/hooks/use-confirm'
 
+import { ActiveState } from '../components/active-state'
+import { CancelledState } from '../components/cancelled-state'
 import { MeetingIdViewHeader } from '../components/meeting-id-view-header'
+import { ProcessingState } from '../components/processing-state'
+import { UpcomingState } from '../components/upcoming-state'
 import UpdateMeetingDialog from '../components/update-meeting-dialog'
 
 interface MeetingIdViewProps {
@@ -69,6 +73,12 @@ const MeetingIdView = ({ meetingId }: MeetingIdViewProps) => {
     await removeMeeting.mutateAsync({ id: meetingId })
   }
 
+  const isActive = data.status === 'active'
+  const isUpcoming = data.status === 'upcoming'
+  const isCancelled = data.status === 'cancelled'
+  const isCompleted = data.status === 'completed'
+  const isProcessing = data.status === 'processing'
+
   return (
     <>
       <RemoveConfirmation />
@@ -84,7 +94,17 @@ const MeetingIdView = ({ meetingId }: MeetingIdViewProps) => {
           onEdit={() => setUpdateMeetingDialogOpen(true)}
           onRemove={handleRemoveMeeting}
         />
-        {JSON.stringify(data, null, 2)}
+        {isCancelled && <CancelledState />}
+        {isCompleted && <div>completed</div>}
+        {isProcessing && <ProcessingState />}
+        {isUpcoming && (
+          <UpcomingState
+            meetingId={meetingId}
+            onCancelMeeting={handleRemoveMeeting}
+            isCancelling={false} // todo: disable while removing
+          />
+        )}
+        {isActive && <ActiveState meetingId={meetingId} />}
       </div>
     </>
   )


### PR DESCRIPTION
This pull request introduces new UI components to represent different meeting states and integrates them into the meeting details view. The main changes involve enhancing the user experience by providing clear visual feedback for each meeting status (upcoming, active, cancelled, processing, completed), and making the `EmptyState` component more flexible by allowing custom images.

**Meeting State UI Enhancements:**

* Added new components: `UpcomingState`, `ActiveState`, `CancelledState`, and `ProcessingState`, each displaying a tailored message and illustration for their respective meeting statuses. These components use the `EmptyState` component with different props. [[1]](diffhunk://#diff-a7f693abd6dd30c825ef0c365288e8060797d03e0bbd9b70fc2210edee9cec49R1-R48) [[2]](diffhunk://#diff-32d4fe024763aed68a835331a5c1dd3e9facff82aad4593bda2785d0bb08d1ddR1-R33) [[3]](diffhunk://#diff-6743a2c9fbc7c16c3c27ff6840c51c068d4088db20d70366a5d3f5dcf939b927R1-R15) [[4]](diffhunk://#diff-bdacbca9799f031bf20da3370b119aae859315afb8a8696342ae2a45e9f54dbbR1-R15)
* Updated the meeting details view (`meeting-id-view.tsx`) to render the appropriate state component based on the current meeting status, replacing the previous raw JSON output. [[1]](diffhunk://#diff-848fbbb657da7a591cc1e4a760735f9f56f3abe922621fe10de9b31c512e770bR17-R21) [[2]](diffhunk://#diff-848fbbb657da7a591cc1e4a760735f9f56f3abe922621fe10de9b31c512e770bR76-R81) [[3]](diffhunk://#diff-848fbbb657da7a591cc1e4a760735f9f56f3abe922621fe10de9b31c512e770bL87-R107)

**Component Improvements:**

* Enhanced the `EmptyState` component to accept an optional `image` prop, allowing different illustrations to be displayed for each state.